### PR TITLE
Add page redirecting to the latest LOOT thread.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,7 @@
 # replicate GitHub's behaviour properly.
 safe: true
 lsi: false
+
+# Enable page redirection
+gems:
+  - jekyll-redirect-from

--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,6 @@ lsi: false
 # Enable page redirection
 gems:
   - jekyll-redirect-from
+
+whitelist:
+  - jekyll-redirect-from

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -46,7 +46,7 @@
                     <span>Wiki</span>
                 </a>
                 <div class="subheader">Support &amp; Discussion</div>
-                <a class="mdl-navigation__link mdl-navigation__link--icon" href="http://forums.bethsoft.com/topic/1588424-rel-loot-thread-22/">
+                <a class="mdl-navigation__link mdl-navigation__link--icon" href="/latest-thread/">
                     <i class="material-icons">forum</i>
                     <span>Forum Thread</span>
                 </a>

--- a/latest-thread.html
+++ b/latest-thread.html
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Latest LOOT thread
+permalink: /latest-thread/
+redirect_to:
+  - http://forums.bethsoft.com/topic/1588424-rel-loot-thread-22/
+---
+
+<p>The latest thread about LOOT on the Bethesda forums can be found at:
+    <a href="http://forums.bethsoft.com/topic/1588424-rel-loot-thread-22/">
+        http://forums.bethsoft.com/topic/1588424-rel-loot-thread-22/
+    </a>
+</p>

--- a/latest-thread.html
+++ b/latest-thread.html
@@ -4,10 +4,9 @@ title: Latest LOOT thread
 permalink: /latest-thread/
 redirect_to:
   - http://forums.bethsoft.com/topic/1588424-rel-loot-thread-22/
+forum_thread: http://forums.bethsoft.com/topic/1588424-rel-loot-thread-22/
 ---
 
 <p>The latest thread about LOOT on the Bethesda forums can be found at:
-    <a href="http://forums.bethsoft.com/topic/1588424-rel-loot-thread-22/">
-        http://forums.bethsoft.com/topic/1588424-rel-loot-thread-22/
-    </a>
+    <a href="{{ page.forum_thread }}">{{ page.forum_thread }}</a>
 </p>


### PR DESCRIPTION
This will allow us to only update the LOOT thread link in one place (well, three as per this commit, but they're all in the same file :)), which should lead to a much reduced chance of masterlists becoming obsolete across games and versions.

The only downside (that I can think of) is that browsers (including LOOT's CEF) will no longer immediately recognise that the new thread has not been visited. I feel that this is insignificant, as users could already not see, based on the link, whether there had been new replies or other important info posted to the thread. If people want to keep that up to date with the thread, Bethesda's forum has a way to subscribe to threads.

**NOTE:** This has not been tested, as I don't have a working `jekyll` setup set up locally.