### PR TITLE
Update "Introduction To Load Orders" for ESL and CC info

### DIFF
--- a/docs/help/Introduction-To-Load-Orders.html
+++ b/docs/help/Introduction-To-Load-Orders.html
@@ -5,7 +5,7 @@ title: Introduction To Load Orders
 
 <p>This page provides a general overview of load ordering in the games LOOT supports for those who are unfamiliar with the concept. For simplicity, "the game" will be used when the text refers to any of the games that LOOT supports.</p>
 
-<p>Mod plugins for the game are files that end in <code>.esp</code> or <code>.esm</code>. These files are created by the game's official editing tools, or by third-party modders' tools. They contain various data <em>records</em>, which cover almost all aspects of what is in the game – NPCs, items, races, interiors, worlds, quests, etc. – and can either be new or changes to the records added by another plugin.</p>
+<p>Mod plugins for the game are files that end in <code>.esp</code>, <code>.esm</code>, or <code>.esl</code>. These files are created by the game's official editing tools, or by third-party modders' tools. They contain various data <em>records</em>, which cover almost all aspects of what is in the game – NPCs, items, races, interiors, worlds, quests, etc. – and can either be new or changes to the records added by another plugin.</p>
 
 <p>When the game is run, it loads each installed plugin one by one in a certain <em>load order</em>. The load order is important for two reasons:</p>
 
@@ -17,14 +17,17 @@ title: Introduction To Load Orders
 <p>There are a few hardcoded rules related to load order:</p>
 
 <ul>
-  <li>Master plugins always load before non-master plugins. The difference between the two plugin types isn't really relevant, except that a plugin's type is decided by a setting inside it, and not by its file extension (even though <code>.esm</code> stands for Elder Scrolls Master).</li>
-  <li>There is a limit of 255 active plugins that can be loaded by the game. This isn't strictly a load <em>order</em> thing, but is worth mentioning.</li>
+  <li>Master plugins always load before non-master plugins. The difference between the two plugin types isn't really relevant, except that a plugin's type is decided by a setting inside it, and not normally by its file extension (even though <code>.esm</code> stands for Elder Scrolls Master). For Fallout 4 and Skyrim Special Edition, <code>.esm</code> and <code>.esl</code> files are always considered masters though, regardless of their plugin flags.</li>
+  <li>There is a limit of 255 active <code>.esm</code> and <code>.esp</code> plugins that can be loaded by the game. This isn't strictly a load <em>order</em> thing, but is worth mentioning. For Fallout 4 and Skyrim Special Edition, there can additionally be loaded up to 4096 active <code>.esl</code> plugins.</li>
   <li>In Skyrim and Fallout 4, the game master file (<code>Skyrim.esm</code> and <code>Fallout4.esm</code> respectively) always loads before all other plugins.</li>
   <li>In Skyrim, if <code>Update.esm</code> is present, it is always loaded. It loads after all other master plugins, unless it has another position explicitly set.</li>
   <li>In Fallout 4, if any of the DLC plugins are present, they are always loaded. They load after all other master plugins, in the order of their release, unless they have other positions explicitly set.</li>
+  <li>In Fallout 4 and Skyrim Special Edition, if any Creation Club content plugins are present, they are always loaded. They load after the game DLCs but before any custom masters.</li>
 </ul>
 
-<p>A plugin's position in the load order is often displayed by mod managers as a hexadecimal number, from 00 to FE (0 to 254 in decimal). The plugin with position 00 loads first, and the plugin with position FE is loaded last. Hexadecimal numbers are used to display the load order positions of plugins because these numbers form the first two digits of the code that the game uses to reference the records that the plugin adds, so knowing the numbers allows modders and mod users to determine from which plugin a record is from.</p>
+<p>A plugin's position in the load order is often displayed by mod managers as a hexadecimal number, from 00 to FE (0 to 254 in decimal). The plugin with position 00 loads first, and the plugin with position FE is loaded last (except for <code>.esl</code> files, see below). Hexadecimal numbers are used to display the load order positions of plugins because these numbers form the first two digits of the code that the game uses to reference the records that the plugin adds, so knowing the numbers allows modders and mod users to determine from which plugin a record is from.</p>
+
+<p>For Fallout 4 and Skyrim Special Edition, Light Master plugins (<code>.esl</code> files) are listed as position FE, but actually load in the position dictated by the load order.</p>
 
 <p>In Oblivion, Fallout 3 and Fallout: New Vegas, load order is determined by plugin timestamps, and the plugins you have accessed are listed in <code>%LOCALAPPDATA%\&lt;game&gt;\plugins.txt</code>. As such, it's best to use a mod manager to create a backup of your load order.</p>
 


### PR DESCRIPTION
The Introduction to Load Orders article is slightly outdated in not mentioned Creation Club plugins or `.esl` files. I've updated it a bit to the best of my current understanding. Please review before I push it live.