### PR TITLE
Improve Masterlist Search regex matching

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -28,10 +28,8 @@ var resultsDiv = document.getElementById('results');
 ///////////////////
 
 function isRegexEntry(name) {
-    var end = name.substring(name.length - 5).toLowerCase();
-    if (end == '\\.esp' || end == '\\.esm') {
-        return true;
-    }
+    const regChars = [':', '\\', '*', '?', '|'];
+    return regChars.some(regChar => name.includes(regChar));
 }
 
 function readMasterlist(response) {


### PR DESCRIPTION
[Reported](https://discord.com/channels/473542112974077963/473543945188802580/940543906255360020) in Discord

> @WrinklyNinja#2573, the Masterlist Search doesn't seems to parse regex plugins with special regex characters in the extension as regex plugins. For example, if I look up `PRP.esp` in the Fallout4 masterlist, `P(PF|RP.*)\.es[mp]` isn't found even though they match. However, if I enter `P(PF|RP.*)\.es[mp]`, it matches as if it weren't treated as a regex plugin.